### PR TITLE
Add convenience functions for adding hrefs

### DIFF
--- a/src/hiccup.rs
+++ b/src/hiccup.rs
@@ -1,5 +1,6 @@
 use serde_json::json;
 use serde_json::Value;
+use std::collections::{HashMap, HashSet};
 
 /// Add 'href' attributes to each 'a' tag that has a 'resource', but not an 'href'.
 /// Return the updated list.
@@ -67,6 +68,176 @@ pub fn insert_href_by_depth(element: &Value, href: &str, depth: usize) -> Value 
                 }
                 Value::Array(x) => {
                     output.push(insert_href_by_depth(&json!(x), href, depth + 1));
+                }
+                _ => panic!(
+                    "Bad type for '{tag}' child '{child}' at loc {depth}",
+                    tag = tag_string,
+                    child = child,
+                    depth = depth + 1
+                ),
+            }
+        }
+    }
+
+    Value::Array(output)
+}
+
+/// Add 'href' attributes to each 'a' tag that has a 'resource', but not an 'href'.
+/// The 'href' attributes are specified with a map from CURIEs to the desired 'href' pattern.
+/// Return the updated list.
+///
+/// * param `element` - hiccup-style list to add 'href' attributes to
+/// * param `curie_2_href` - map from CURIEs to pattern for hrefs where the substring "{curie}" is replaced with resource
+/// * return - copy of element with added 'href'
+pub fn set_hrefs(element: &Value, curie_2_href : &HashMap<String,String>) -> Value {
+    set_hrefs_by_depth(element, curie_2_href, 0)
+}
+
+/// Add 'href' attributes to each 'a' tag that has a 'resource', but not an 'href'.
+/// The 'href' attributes are specified with a map from CURIEs to the desired 'href' pattern.
+/// Return the updated list.
+///
+/// * param `element` - hiccup-style list to add 'href' attributes to
+/// * param `curie_2_href` - map from CURIEs to pattern for hrefs where the substring "{curie}" is replaced with resource
+/// * param `depth` - list depth of current element
+/// * return - copy of element with added 'href'
+pub fn set_hrefs_by_depth(element: &Value, curie_2_href : &HashMap<String,String>, depth: usize) -> Value {
+    let mut element_pointer = 0;
+    let render_element = element.clone();
+    let render_element = match render_element {
+        Value::Array(x) => x,
+        _ => panic!("Element is not a list: {:?}", element),
+    };
+    if render_element.is_empty() {
+        panic!("Element is an empty list")
+    }
+
+    let tag = render_element[0].clone();
+    element_pointer += 1;
+    let tag_string = match tag {
+        Value::String(x) => x,
+        _ => panic!(
+            "Tag '{tag}' at loc {depth} is not a string",
+            tag = tag,
+            depth = depth
+        ),
+    };
+
+    let mut output = vec![json!(tag_string.clone())];
+
+    if render_element.len() - element_pointer > 0 {
+        match render_element[element_pointer].clone() {
+            Value::Object(mut attr) => {
+                element_pointer += 1;
+                if tag_string.eq("a") & !attr.contains_key("href") & attr.contains_key("resource"){
+                    if curie_2_href.contains_key(attr["resource"].as_str().unwrap()) {
+
+                        let href = curie_2_href.get(attr["resource"].as_str().unwrap()).unwrap();
+                        attr.insert(
+                            String::from("href"),
+                            json!(href.replace("{curie}", attr["resource"].as_str().unwrap())),
+                        );
+                    }
+                }
+                output.push(Value::Object(attr.clone()));
+            }
+            _ => {}
+        }
+    }
+
+    if render_element.len() - element_pointer > 0 {
+        for i in element_pointer..render_element.len() {
+            let child = render_element[i].clone();
+            match child {
+                Value::String(x) => {
+                    output.push(json!(x));
+                }
+                Value::Array(x) => {
+                    output.push(set_hrefs_by_depth(&json!(x), curie_2_href, depth + 1));
+                }
+                _ => panic!(
+                    "Bad type for '{tag}' child '{child}' at loc {depth}",
+                    tag = tag_string,
+                    child = child,
+                    depth = depth + 1
+                ),
+            }
+        }
+    }
+
+    Value::Array(output)
+}
+
+/// Add 'href' attributes to each 'a' tag that has a 'resource', but not an 'href' and is in
+/// the list of target resources.
+/// Return the updated list.
+///
+/// * param `element` - hiccup-style list to add 'href' attributes to
+/// * param `targets` -  set of CURIEs href values are added
+/// * return - copy of element with added 'href'
+pub fn insert_href_for(element: &Value, href: &str, targets : &HashSet<String>) -> Value {
+    insert_href_for_by_depth(element, href, targets, 0)
+}
+
+/// Add 'href' attributes to each 'a' tag that has a 'resource', but not an 'href' and is in
+/// the list of target resources.
+/// Return the updated list.
+///
+/// * param `element` - hiccup-style list to add 'href' attributes to
+/// * param `targets` -  set of CURIEs href values are added
+/// * param `depth` - list depth of current element
+/// * return - copy of element with added 'href'
+pub fn insert_href_for_by_depth(element: &Value, href: &str, targets : &HashSet<String>, depth: usize) -> Value {
+    let mut element_pointer = 0;
+    let render_element = element.clone();
+    let render_element = match render_element {
+        Value::Array(x) => x,
+        _ => panic!("Element is not a list: {:?}", element),
+    };
+    if render_element.is_empty() {
+        panic!("Element is an empty list")
+    }
+
+    let tag = render_element[0].clone();
+    element_pointer += 1;
+    let tag_string = match tag {
+        Value::String(x) => x,
+        _ => panic!(
+            "Tag '{tag}' at loc {depth} is not a string",
+            tag = tag,
+            depth = depth
+        ),
+    };
+
+    let mut output = vec![json!(tag_string.clone())];
+
+    if render_element.len() - element_pointer > 0 {
+        match render_element[element_pointer].clone() {
+            Value::Object(mut attr) => {
+                element_pointer += 1;
+                if tag_string.eq("a") & !attr.contains_key("href") & attr.contains_key("resource"){
+                    if targets.contains(attr["resource"].as_str().unwrap()) {
+                        attr.insert(
+                            String::from("href"),
+                            json!(href.replace("{curie}", attr["resource"].as_str().unwrap())),
+                        );
+                    }
+                }
+                output.push(Value::Object(attr.clone()));
+            }
+            _ => {}
+        }
+    }
+
+    if render_element.len() - element_pointer > 0 {
+        for i in element_pointer..render_element.len() {
+            let child = render_element[i].clone();
+            match child {
+                Value::String(x) => {
+                    output.push(json!(x));
+                }
+                Value::Array(x) => {
+                    output.push(insert_href_for_by_depth(&json!(x), href, targets, depth + 1));
                 }
                 _ => panic!(
                     "Bad type for '{tag}' child '{child}' at loc {depth}",


### PR DESCRIPTION
- The function `insert_href` allows us to add hrefs for *all* hyperlinks about resources in a uniform manner.
- The function `insert_href_for` allows us to add hrefs for *some set of* hyperlinks about resources. The signature of `insert_href_for` only differs from `insert_href` by one argument which is the set of resources for which "hrefs" are supposed to be added
-  The function `set_hrefs` allows us to specify with a HashMap what kind of href pattern is supposed to be used for a given resource. For example, the map `{"pre:example1" : "?id={curie}", "pre:example2" : "table/?id={curie}"}` specifies two different href patterns that are used for adding hrefs to different resources. (This should make it straightforward to add custom links to resources.)